### PR TITLE
fix nil-reference issue in QuotedString module

### DIFF
--- a/lib/webmachine/quoted_string.rb
+++ b/lib/webmachine/quoted_string.rb
@@ -28,12 +28,12 @@ module Webmachine
 
     # Escapes quotes within a quoted string.
     def escape_quotes(str)
-      str.gsub(/"/, '\\"')
+      String(str).gsub(/"/, '\\"')
     end
 
     # Unescapes quotes within a quoted string
     def unescape_quotes(str)
-      str.gsub(%r{\\}, '')
+      String(str).gsub(%r{\\}, '')
     end
   end
 end

--- a/spec/webmachine/quoted_string_spec.rb
+++ b/spec/webmachine/quoted_string_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe Webmachine::QuotedString do
+  include Webmachine::QuotedString
+
+  describe '#quote' do
+    context 'when the string is present and nonempty, has no quotes' do
+      subject { quote('123') }
+
+      it { is_expected.to eq('"123"') }
+    end
+
+    context 'when the string is present and nonempty, has embedded quotes' do
+      let(:string) { '1"2"3' }
+      subject { quote('1"2"3') }
+
+      it { is_expected.to eq('"1\"2\"3"') }
+    end
+
+    context 'when the string is present and empty' do
+      subject { quote('') }
+
+      it { is_expected.to eq("\"\"") }
+    end
+
+    context 'when the string is nil' do
+      subject { quote(nil) }
+
+      it { is_expected.to eq("\"\"") }
+    end
+  end
+
+  describe '#unquote' do
+    context 'when the string is present and nonempty, has no quotes' do
+      subject { unquote('123') }
+
+      it { is_expected.to eq('123') }
+    end
+
+    context 'when the string is present and nonempty, has embedded quotes' do
+      let(:string) { '"1\"2\"3"' }
+      subject { unquote(string) }
+
+      it { is_expected.to eq('1"2"3') }
+    end
+
+    context 'when the string is present and empty' do
+      subject { unquote('') }
+
+      it { is_expected.to eq('') }
+    end
+
+    context 'when the string is nil' do
+      subject { unquote(nil) }
+
+      it { is_expected.to eq(nil) }
+    end
+  end
+end


### PR DESCRIPTION
fixes #201, `#quote` will no longer throw a nil-ref when passed a nil argument.

also adds specs for `Webmachine::QuotedString#quote` and `#unquote`. I didn't see any existing specs in the spec folder. There was one case where I encoded the current behavior, but think that maybe it should not behave this way:

````ruby

context 'when the string is nil' do
  subject { unquote(nil) }

  it { is_expected.to eq(nil) }
end
````

IMO, either this should return `""`, or `quote(nil)` should return `nil`, rather than `""`. The former is perhaps more convenient, the latter is so that the invariants

````ruby
quote(unquote(str)) == str
````
and

````ruby
unquote(quote(str)) == str
````

hold. Right now, if `str` is nil, it would get 'promoted' to an empty string. Not sure what is preferable there.