### PR TITLE
Use Rack::Request#url instead of env['REQUEST_URI']

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :test do
   gem "rspec", '~> 3.0.0'
   gem "rspec-its"
   gem "rack"
+  gem "rack-test"
 end
 
 group :webservers do

--- a/lib/webmachine/adapters/rack.rb
+++ b/lib/webmachine/adapters/rack.rb
@@ -37,6 +37,7 @@ module Webmachine
       # Used to override default Rack server options (useful in testing)
       DEFAULT_OPTIONS = {}
 
+      REQUEST_URI = 'REQUEST_URI'.freeze
       VERSION_STRING = "#{Webmachine::SERVER_STRING} Rack/#{::Rack.version}".freeze
       NEWLINE = "\n".freeze
 
@@ -59,7 +60,7 @@ module Webmachine
 
         rack_req = ::Rack::Request.new env
         request = Webmachine::Request.new(rack_req.request_method,
-                                          rack_req.url,
+                                          ENV[REQUEST_URI] || rack_req.url,
                                           headers,
                                           RequestBody.new(rack_req))
 

--- a/lib/webmachine/adapters/rack.rb
+++ b/lib/webmachine/adapters/rack.rb
@@ -59,10 +59,6 @@ module Webmachine
         headers = Webmachine::Headers.from_cgi(env)
 
         rack_req = ::Rack::Request.new env
-        if env[REQUEST_URI] != rack_req.url
-          puts "REQUEST_URI #{env[REQUEST_URI]}"
-          puts "rack_req.url #{rack_req.url}"
-        end
         request = Webmachine::Request.new(rack_req.request_method,
                                           rack_req.url,
                                           headers,

--- a/lib/webmachine/adapters/rack.rb
+++ b/lib/webmachine/adapters/rack.rb
@@ -60,7 +60,7 @@ module Webmachine
 
         rack_req = ::Rack::Request.new env
         request = Webmachine::Request.new(rack_req.request_method,
-                                          ENV[REQUEST_URI] || rack_req.url,
+                                          env[REQUEST_URI] || rack_req.url,
                                           headers,
                                           RequestBody.new(rack_req))
 

--- a/lib/webmachine/adapters/rack.rb
+++ b/lib/webmachine/adapters/rack.rb
@@ -55,7 +55,7 @@ module Webmachine
 
         rack_req = ::Rack::Request.new env
         request = Webmachine::Request.new(rack_req.request_method,
-                                          rack_req.url,
+                                          env['PATH_INFO'],
                                           headers,
                                           RequestBody.new(rack_req))
 

--- a/lib/webmachine/adapters/rack.rb
+++ b/lib/webmachine/adapters/rack.rb
@@ -55,7 +55,7 @@ module Webmachine
 
         rack_req = ::Rack::Request.new env
         request = Webmachine::Request.new(rack_req.request_method,
-                                          env['REQUEST_URI'],
+                                          rack_req.url,
                                           headers,
                                           RequestBody.new(rack_req))
 

--- a/lib/webmachine/adapters/rack.rb
+++ b/lib/webmachine/adapters/rack.rb
@@ -59,8 +59,12 @@ module Webmachine
         headers = Webmachine::Headers.from_cgi(env)
 
         rack_req = ::Rack::Request.new env
+        if env[REQUEST_URI] != rack_req.url
+          puts "REQUEST_URI #{env[REQUEST_URI]}"
+          puts "rack_req.url #{rack_req.url}"
+        end
         request = Webmachine::Request.new(rack_req.request_method,
-                                          env[REQUEST_URI] || rack_req.url,
+                                          rack_req.url,
                                           headers,
                                           RequestBody.new(rack_req))
 

--- a/lib/webmachine/adapters/rack.rb
+++ b/lib/webmachine/adapters/rack.rb
@@ -37,7 +37,6 @@ module Webmachine
       # Used to override default Rack server options (useful in testing)
       DEFAULT_OPTIONS = {}
 
-      REQUEST_URI = 'REQUEST_URI'.freeze
       VERSION_STRING = "#{Webmachine::SERVER_STRING} Rack/#{::Rack.version}".freeze
       NEWLINE = "\n".freeze
 
@@ -60,7 +59,7 @@ module Webmachine
 
         rack_req = ::Rack::Request.new env
         request = Webmachine::Request.new(rack_req.request_method,
-                                          env[REQUEST_URI],
+                                          rack_req.url,
                                           headers,
                                           RequestBody.new(rack_req))
 

--- a/spec/webmachine/adapters/rack_spec.rb
+++ b/spec/webmachine/adapters/rack_spec.rb
@@ -2,6 +2,7 @@ require 'webmachine/adapter'
 require 'webmachine/adapters/rack'
 require 'spec_helper'
 require 'webmachine/spec/adapter_lint'
+require 'rack/test'
 
 describe Webmachine::Adapters::Rack do
   it_should_behave_like :adapter_lint do
@@ -31,6 +32,26 @@ describe Webmachine::Adapters::Rack::RackResponse do
       rack_response = described_class.new(double(:body), 406, {})
       rack_status, rack_headers, rack_body = rack_response.finish
       expect(rack_headers).not_to have_key("Content-Type")
+    end
+  end
+end
+
+describe Webmachine::Adapters::Rack do
+  let(:app) do
+    Webmachine::Application.new.tap do |app|
+      app.add_route(["test"], Test::Resource)
+      app.configure do | config |
+        config.adapter = :Rack
+      end
+    end.adapter
+  end
+
+  context "using Rack::Test" do
+    include Rack::Test::Methods
+
+    it "provides the full request URI" do
+      rack_response = get "test", nil, {"HTTP_ACCEPT" => "test/response.request_uri"}
+      expect(rack_response.body).to eq "http://example.org/test"
     end
   end
 end


### PR DESCRIPTION
env['REQUEST_URI'] is not populated by all frameworks.