### PR TITLE
Support webmachine being mapped inside a parent rack app

### DIFF
--- a/documentation/adapters.md
+++ b/documentation/adapters.md
@@ -10,13 +10,15 @@ run on any webserver that provides a Rack interface. It also lets it run on
 In order to be compatible with popular deployment stacks,
 Webmachine has a [Rack](https://github.com/rack/rack) adapter (thanks to Jamis Buck).
 
-Webmachine can be used with Rack middlware features such as Rack::Map and Rack::Cascade as long as:
-
-1. The Webmachine app is mounted at the root directory.
-2. Any requests/responses that are handled by the Webmachine app are not modified by the middleware. The behaviours that are encapsulated in Webmachine assume that no modifications
+Webmachine can be used with Rack middlware features such as Rack::Map and Rack::Cascade as long as any requests/responses that are handled by the Webmachine app are **not** modified by the middleware. The behaviours that are encapsulated in Webmachine assume that no modifications
 are done to requests or response outside of Webmachine.
 
 Keep in mind that Webmachine already supports many things that Rack middleware is used for with other HTTP frameworks (eg. etags, specifying supported/preferred Accept and Content-Types).
+
+The base `Webmachine::Adapters::Rack` class assumes the Webmachine application
+is mounted at the route path `/` (i.e. not using `Rack::Builder#map` or Rails
+`ActionDispatch::Routing::Mapper::Base#mount`). In order to
+map to a subpath, use the `Webmachine::Adapters::RackMapped` adapter instead.
 
 For an example of using Webmachine with Rack middleware, see the [Pact Broker][middleware-example].
 

--- a/lib/webmachine/adapters/rack.rb
+++ b/lib/webmachine/adapters/rack.rb
@@ -97,7 +97,13 @@ module Webmachine
         Webmachine::Request.new(rack_req.request_method,
                                 rack_req.url,
                                 headers,
-                                RequestBody.new(rack_req))
+                                RequestBody.new(rack_req),
+                                routing_tokens(rack_req)
+                               )
+      end
+
+      def routing_tokens(rack_req)
+        nil # no-op for default, un-mapped rack adapter
       end
 
       class RackResponse
@@ -173,13 +179,10 @@ module Webmachine
     end # class Rack
 
     class RackMapped < Rack
-      def build_webmachine_request(rack_req, headers)
-        request = super
+      def routing_tokens(rack_req)
         routing_match = rack_req.path_info.match(Webmachine::Request::ROUTING_PATH_MATCH)
         routing_path = routing_match ? routing_match[1] : ""
-        routing_tokens = routing_path.split(SLASH)
-        request.routing_tokens = routing_tokens
-        request
+        routing_path.split(SLASH)
       end
     end
 

--- a/lib/webmachine/adapters/rack.rb
+++ b/lib/webmachine/adapters/rack.rb
@@ -92,6 +92,11 @@ module Webmachine
         rack_res.finish
       end
 
+      protected
+      def routing_tokens(rack_req)
+        nil # no-op for default, un-mapped rack adapter
+      end
+
       private
       def build_webmachine_request(rack_req, headers)
         Webmachine::Request.new(rack_req.request_method,
@@ -100,10 +105,6 @@ module Webmachine
                                 RequestBody.new(rack_req),
                                 routing_tokens(rack_req)
                                )
-      end
-
-      def routing_tokens(rack_req)
-        nil # no-op for default, un-mapped rack adapter
       end
 
       class RackResponse
@@ -179,6 +180,7 @@ module Webmachine
     end # class Rack
 
     class RackMapped < Rack
+      protected
       def routing_tokens(rack_req)
         routing_match = rack_req.path_info.match(Webmachine::Request::ROUTING_PATH_MATCH)
         routing_path = routing_match ? routing_match[1] : ""

--- a/lib/webmachine/adapters/rack.rb
+++ b/lib/webmachine/adapters/rack.rb
@@ -12,9 +12,12 @@ module Webmachine
     # A minimal "shim" adapter to allow Webmachine to interface with Rack. The
     # intention here is to allow Webmachine to run under Rack-compatible
     # web-servers, like unicorn and pow.
+    #
     # The adapter expects your Webmachine application to be mounted at the root path -
     # it will NOT allow you to nest your Webmachine application at an arbitrary path
     # eg. map "/api" { run MyWebmachineAPI }
+    # To use map your Webmachine application at an arbitrary path, use the
+    # `Webmachine::Adapters::RackMapped` subclass instead.
     #
     # To use this adapter, create a config.ru file and populate it like so:
     #
@@ -179,6 +182,24 @@ module Webmachine
       end # class RequestBody
     end # class Rack
 
+    # Provides the same functionality as the parent Webmachine::Adapters::Rack
+    # adapter, but allows the Webmachine application to be hosted at an
+    # arbitrary path in a parent Rack application (as in Rack `map` or Rails
+    # routing `mount`)
+    #
+    # This functionality is separated out from the parent class to preserve
+    # backward compatibility in the behaviour of the parent Rack adpater.
+    #
+    # To use the adapter in a parent Rack application, map the Webmachine
+    # application as follows in a rackup file or Rack::Builder:
+    #
+    #   map '/foo' do
+    #     run SomeotherRackApp
+    #
+    #     map '/bar' do
+    #       run MyWebmachineApp.adapter
+    #     end
+    #   end
     class RackMapped < Rack
       protected
       def routing_tokens(rack_req)

--- a/lib/webmachine/adapters/rack.rb
+++ b/lib/webmachine/adapters/rack.rb
@@ -100,13 +100,18 @@ module Webmachine
         nil # no-op for default, un-mapped rack adapter
       end
 
+      def base_uri(rack_req)
+        nil # no-op for default, un-mapped rack adapter
+      end
+
       private
       def build_webmachine_request(rack_req, headers)
         Webmachine::Request.new(rack_req.request_method,
                                 rack_req.url,
                                 headers,
                                 RequestBody.new(rack_req),
-                                routing_tokens(rack_req)
+                                routing_tokens(rack_req),
+                                base_uri(rack_req)
                                )
       end
 
@@ -206,6 +211,14 @@ module Webmachine
         routing_match = rack_req.path_info.match(Webmachine::Request::ROUTING_PATH_MATCH)
         routing_path = routing_match ? routing_match[1] : ""
         routing_path.split(SLASH)
+      end
+
+      def base_uri(rack_req)
+        # rack SCRIPT_NAME env var doesn't end with "/". This causes weird
+        # behavour when URI.join concatenates URI components in
+        # Webmachine::Decision::Flow#n11
+        script_name = rack_req.script_name + SLASH
+        URI.join(rack_req.base_url, script_name)
       end
     end
 

--- a/lib/webmachine/dispatcher/route.rb
+++ b/lib/webmachine/dispatcher/route.rb
@@ -79,13 +79,11 @@ module Webmachine
         raise ArgumentError, t('not_resource_class', :class => resource.name) unless resource < Resource
       end
 
-      PATH_MATCH = /^\/(.*)/.freeze
-
       # Determines whether the given request matches this route and
       # should be dispatched to the {#resource}.
       # @param [Reqeust] request the request object
       def match?(request)
-        tokens = request.uri.path.match(PATH_MATCH)[1].split(SLASH)
+        tokens = request.routing_tokens
         bind(tokens, {}) && guards.all? { |guard| guard.call(request) }
       end
 
@@ -93,9 +91,9 @@ module Webmachine
       # route, including path bindings.
       # @param [Request] request the request object
       def apply(request)
-        request.disp_path = request.uri.path.match(PATH_MATCH)[1]
+        request.disp_path = request.routing_tokens.join(SLASH)
         request.path_info = @bindings.dup
-        tokens = request.disp_path.split(SLASH)
+        tokens = request.routing_tokens
         depth, trailing = bind(tokens, request.path_info)
         request.path_tokens = trailing || []
       end

--- a/lib/webmachine/request.rb
+++ b/lib/webmachine/request.rb
@@ -13,6 +13,7 @@ module Webmachine
 
     attr_reader :method, :uri, :headers, :body
     attr_accessor :disp_path, :path_info, :path_tokens
+    attr_writer :routing_tokens
 
     # @param [String] method the HTTP request method
     # @param [URI] uri the requested URI, including host, scheme and
@@ -162,6 +163,12 @@ module Webmachine
     #   true if this request was made with the OPTIONS method
     def options?
       method == OPTIONS_METHOD
+    end
+
+    ROUTING_PATH_MATCH = /^\/(.*)/.freeze
+
+    def routing_tokens
+      @routing_tokens ||= uri.path.match(ROUTING_PATH_MATCH)[1].split(SLASH)
     end
 
     private

--- a/lib/webmachine/request.rb
+++ b/lib/webmachine/request.rb
@@ -20,8 +20,8 @@ module Webmachine
     # @param [Headers] headers the HTTP request headers
     # @param [String,#to_s,#each,nil] body the entity included in the
     #   request, if present
-    def initialize(method, uri, headers, body, routing_tokens=nil)
-      @method, @headers, @body = method, headers, body
+    def initialize(method, uri, headers, body, routing_tokens=nil, base_uri=nil)
+      @method, @headers, @body, @base_uri = method, headers, body, base_uri
       @uri = build_uri(uri, headers)
       @routing_tokens = routing_tokens || @uri.path.match(ROUTING_PATH_MATCH)[1].split(SLASH)
     end

--- a/lib/webmachine/request.rb
+++ b/lib/webmachine/request.rb
@@ -11,9 +11,8 @@ module Webmachine
 
     extend Forwardable
 
-    attr_reader :method, :uri, :headers, :body
+    attr_reader :method, :uri, :headers, :body, :routing_tokens
     attr_accessor :disp_path, :path_info, :path_tokens
-    attr_writer :routing_tokens
 
     # @param [String] method the HTTP request method
     # @param [URI] uri the requested URI, including host, scheme and
@@ -21,9 +20,10 @@ module Webmachine
     # @param [Headers] headers the HTTP request headers
     # @param [String,#to_s,#each,nil] body the entity included in the
     #   request, if present
-    def initialize(method, uri, headers, body)
+    def initialize(method, uri, headers, body, routing_tokens=nil)
       @method, @headers, @body = method, headers, body
       @uri = build_uri(uri, headers)
+      @routing_tokens = routing_tokens || @uri.path.match(ROUTING_PATH_MATCH)[1].split(SLASH)
     end
 
     def_delegators :headers, :[]
@@ -166,10 +166,6 @@ module Webmachine
     end
 
     ROUTING_PATH_MATCH = /^\/(.*)/.freeze
-
-    def routing_tokens
-      @routing_tokens ||= uri.path.match(ROUTING_PATH_MATCH)[1].split(SLASH)
-    end
 
     private
 

--- a/spec/webmachine/adapters/rack_spec.rb
+++ b/spec/webmachine/adapters/rack_spec.rb
@@ -67,11 +67,38 @@ describe Webmachine::Adapters::Rack do
 end
 
 describe Webmachine::Adapters::RackMapped do
+  class CreateResource < Webmachine::Resource
+    def allowed_methods
+      ["POST"]
+    end
+
+    def content_types_accepted
+      [["application/json", :from_json]]
+    end
+
+    def content_types_provided
+      [["application/json", :to_json]]
+    end
+
+    def post_is_create?
+      true
+    end
+
+    def create_path
+      "created_path_here/123"
+    end
+
+    def from_json
+      response.body = %{ {"foo": "bar"} }
+    end
+  end
+
   let(:app) do
     Rack::Builder.new do
       map '/some/route' do
         run(Webmachine::Application.new do |app|
           app.add_route(["test"], Test::Resource)
+          app.add_route(["create_test"], CreateResource)
           app.configure do | config |
             config.adapter = :RackMapped
           end
@@ -86,6 +113,11 @@ describe Webmachine::Adapters::RackMapped do
     it "provides the full request URI" do
       rack_response = get "some/route/test", nil, {"HTTP_ACCEPT" => "test/response.request_uri"}
       expect(rack_response.body).to eq "http://example.org/some/route/test"
+    end
+
+    it "provides LOCATION header using custom base_uri when creating from POST request" do
+      rack_response = post "/some/route/create_test", %{{"foo": "bar"}}, {"HTTP_ACCEPT" => "application/json", "CONTENT_TYPE" => "application/json"}
+      expect(rack_response.headers["Location"]).to eq("http://example.org/some/route/created_path_here/123")
     end
   end
 end

--- a/spec/webmachine/request_spec.rb
+++ b/spec/webmachine/request_spec.rb
@@ -8,7 +8,8 @@ describe Webmachine::Request do
   let(:headers)         { Webmachine::Headers.new }
   let(:body)            { "" }
   let(:routing_tokens)  { nil }
-  let(:request)         { Webmachine::Request.new(http_method, uri, headers, body, routing_tokens) }
+  let(:base_uri)        { nil }
+  let(:request)         { Webmachine::Request.new(http_method, uri, headers, body, routing_tokens, base_uri) }
 
   it "should provide access to the headers via brackets" do
     subject.headers['Accept'] = "*/*"
@@ -31,8 +32,17 @@ describe Webmachine::Request do
     expect(subject.content_md5).to be_nil
   end
 
-  it "should calculate a base URI" do
-    expect(subject.base_uri).to eq(URI.parse("http://localhost:8080/"))
+  context "base_uri" do
+    it "should calculate a base URI" do
+      expect(subject.base_uri).to eq(URI.parse("http://localhost:8080/"))
+    end
+
+    context "when base_uri has been explicitly set" do
+      let(:base_uri) { URI.parse("http://localhost:8080/some_base_uri/here") }
+      it "should use the provided base_uri" do
+        expect(subject.base_uri).to eq(URI.parse("http://localhost:8080/some_base_uri/here"))
+      end
+    end
   end
 
   it "should provide a hash of query parameters" do

--- a/spec/webmachine/request_spec.rb
+++ b/spec/webmachine/request_spec.rb
@@ -239,4 +239,23 @@ describe Webmachine::Request do
     end
   end
 
+  describe '#routing_tokens' do
+    subject { request.routing_tokens }
+
+    context "haven't be explicitly set" do
+      it "extracts the routing tokens from the path portion of the uri" do
+        expect(subject).to eq(["some", "resource"])
+      end
+    end
+
+    context "have been explicitly set" do
+      before { request.routing_tokens = ["foo", "bar"] }
+
+      it "uses the specified routing_tokens" do
+        expect(subject).to eq(["foo", "bar"])
+      end
+    end
+
+  end
+
 end

--- a/spec/webmachine/request_spec.rb
+++ b/spec/webmachine/request_spec.rb
@@ -3,11 +3,12 @@ require 'spec_helper'
 describe Webmachine::Request do
   subject { request }
 
-  let(:uri)         { URI.parse("http://localhost:8080/some/resource") }
-  let(:http_method) { "GET" }
-  let(:headers)     { Webmachine::Headers.new }
-  let(:body)        { "" }
-  let(:request)     { Webmachine::Request.new(http_method, uri, headers, body) }
+  let(:uri)             { URI.parse("http://localhost:8080/some/resource") }
+  let(:http_method)     { "GET" }
+  let(:headers)         { Webmachine::Headers.new }
+  let(:body)            { "" }
+  let(:routing_tokens)  { nil }
+  let(:request)         { Webmachine::Request.new(http_method, uri, headers, body, routing_tokens) }
 
   it "should provide access to the headers via brackets" do
     subject.headers['Accept'] = "*/*"
@@ -242,14 +243,15 @@ describe Webmachine::Request do
   describe '#routing_tokens' do
     subject { request.routing_tokens }
 
-    context "haven't be explicitly set" do
+    context "haven't been explicitly set" do
+      let(:routing_tokens) { nil }
       it "extracts the routing tokens from the path portion of the uri" do
         expect(subject).to eq(["some", "resource"])
       end
     end
 
     context "have been explicitly set" do
-      before { request.routing_tokens = ["foo", "bar"] }
+      let(:routing_tokens) { ["foo", "bar"] }
 
       it "uses the specified routing_tokens" do
         expect(subject).to eq(["foo", "bar"])


### PR DESCRIPTION
Pull request implementing changes proposed in https://github.com/seancribbs/webmachine-ruby/issues/222

- [x] store routing tokens on request
- [x] use routing tokens for routing
- [x] correctly set `base_uri` for rack mapped requests that explicitly set `routing_tokens`